### PR TITLE
Fix shift+navigation on Unix systems

### DIFF
--- a/src/terminal/unix.rs
+++ b/src/terminal/unix.rs
@@ -74,7 +74,20 @@ impl From<event::Event> for Event {
         match e {
             event::Event::Key(k) => Event::Key(k.into()),
             event::Event::Mouse(m) => Event::Mouse(m.into()),
-            event::Event::Unsupported(v) => Event::Unsupported(v.iter().map(|x| *x as u32).collect()),
+            event::Event::Unsupported(v) => {
+                let vals = v.iter().map(|x| *x as u32).collect();
+                if vals == [27, 91, 49, 59, 50, 65] {
+                    Event::Key(Key::Shift(Box::new(Key::Up)))
+                } else if vals == [27, 91, 49, 59, 50, 66] {
+                    Event::Key(Key::Shift(Box::new(Key::Down)))
+                } else if vals == [27, 91, 49, 59, 50, 67] {
+                    Event::Key(Key::Shift(Box::new(Key::Right)))
+                } else if vals == [27, 91, 49, 59, 50, 68] {
+                    Event::Key(Key::Shift(Box::new(Key::Left)))
+                } else {
+                    Event::Unsupported(vals)
+                }
+            }
         }
     }
 }

--- a/src/terminal/unix.rs
+++ b/src/terminal/unix.rs
@@ -76,13 +76,13 @@ impl From<event::Event> for Event {
             event::Event::Mouse(m) => Event::Mouse(m.into()),
             event::Event::Unsupported(v) => {
                 let vals = v.iter().map(|x| *x as u32).collect();
-                if vals == [27, 91, 49, 59, 50, 65] {
+                if vals == [27, 91, 49, 59, 50, 65] { // <Esc>[1;2A
                     Event::Key(Key::Shift(Box::new(Key::Up)))
-                } else if vals == [27, 91, 49, 59, 50, 66] {
+                } else if vals == [27, 91, 49, 59, 50, 66] { // <Esc>[1;2B
                     Event::Key(Key::Shift(Box::new(Key::Down)))
-                } else if vals == [27, 91, 49, 59, 50, 67] {
+                } else if vals == [27, 91, 49, 59, 50, 67] { // <Esc>[1;2C
                     Event::Key(Key::Shift(Box::new(Key::Right)))
-                } else if vals == [27, 91, 49, 59, 50, 68] {
+                } else if vals == [27, 91, 49, 59, 50, 68] { // <Esc>[1;2D
                     Event::Key(Key::Shift(Box::new(Key::Left)))
                 } else {
                     Event::Unsupported(vals)


### PR DESCRIPTION
This was tested on macOS 10.13 and on Ubuntu 17.04.

I am a complete Rust n00b, so please feel free to give feedback!

I tried to use a `match` expression, but I couldn't get it to work with the arrays, so I made an ugly `if`. Let me know if there's a better way.